### PR TITLE
MSSQL charts - add a value to specify the default MSSQL data directory

### DIFF
--- a/charts/mssqlserver-2019/Chart.yaml
+++ b/charts/mssqlserver-2019/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: mssqlserver-2019
 sources:
 - https://hub.docker.com/r/microsoft/mssql-server-linux/
-version: "1.0.11"
+version: "1.1.0"

--- a/charts/mssqlserver-2019/README.md
+++ b/charts/mssqlserver-2019/README.md
@@ -109,6 +109,7 @@ The configuration parameters in this section control the resources requested and
 | collation        | Default collation for SQL Server                                                               | `SQL_Latin1_General_CP1_CI_AS`   |
 | lcid             | Default languages for SQL Server                                                               | `1033`                           |
 | hadr             | Enable Availability Group                                                                      | `0`                              |
+| replicaCount     | Set the number of replica                                                                      | `1`                              |
 | persistence.enabled | Persist the Data and Log files for SQL Server                                               | `false`                          |
 | persistence.existingDataClaim | Identify an existing Claim to be used for the Data Directory                      | `Commented Out`                  |
 | persistence.storageClass      | Storage Class to be used                                                          | `Commented Out`                  |

--- a/charts/mssqlserver-2019/README.md
+++ b/charts/mssqlserver-2019/README.md
@@ -107,6 +107,7 @@ The configuration parameters in this section control the resources requested and
 | pod.annotations   | Kubernetes pod annotations                                                                    | `{}`                             |
 | pod.labels        | Kubernetes pod labels                                                                         | `{}`                             |
 | collation        | Default collation for SQL Server                                                               | `SQL_Latin1_General_CP1_CI_AS`   |
+| dataDir          | Specify the default SQL data directory                                                         | `/var/opt/mssql`                 |
 | lcid             | Default languages for SQL Server                                                               | `1033`                           |
 | hadr             | Enable Availability Group                                                                      | `0`                              |
 | replicaCount     | Set the number of replica                                                                      | `1`                              |

--- a/charts/mssqlserver-2019/templates/deployment.yaml
+++ b/charts/mssqlserver-2019/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
                  name: {{ template "mssql.fullname" . }}-secret
                  key: sapassword
             - name: MSSQL_DATA_DIR
-              value: /var/opt/mssql
+              value: {{ .Values.dataDir }}
             - name: MSSQL_TCP_PORT
               value: "{{ .Values.service.port }}"
             - name: MSSQL_COLLATION

--- a/charts/mssqlserver-2019/values.yaml
+++ b/charts/mssqlserver-2019/values.yaml
@@ -3,6 +3,7 @@ acceptEula:
 edition:
   value: Developer
 collation: SQL_Latin1_General_CP1_CI_AS
+dataDir: /var/opt/mssql
 lcid: 1033
 hadr: 0
 replicaCount: 1

--- a/charts/mssqlserver-2019/values.yaml
+++ b/charts/mssqlserver-2019/values.yaml
@@ -5,6 +5,7 @@ edition:
 collation: SQL_Latin1_General_CP1_CI_AS
 lcid: 1033
 hadr: 0
+replicaCount: 1
 # Override sapassword in templates/secret.yaml
 # sapassword: "MyStrongPassword1234"
 image:

--- a/charts/mssqlserver-2022/Chart.yaml
+++ b/charts/mssqlserver-2022/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 name: mssqlserver-2022
 sources:
 - https://hub.docker.com/r/microsoft/mssql-server-linux/
-version: "1.0.2"
+version: "1.1.0"

--- a/charts/mssqlserver-2022/README.md
+++ b/charts/mssqlserver-2022/README.md
@@ -109,6 +109,7 @@ The configuration parameters in this section control the resources requested and
 | collation        | Default collation for SQL Server                                                               | `SQL_Latin1_General_CP1_CI_AS`   |
 | lcid             | Default languages for SQL Server                                                               | `1033`                           |
 | hadr             | Enable Availability Group                                                                      | `0`                              |
+| replicaCount     | Set the number of replica                                                                      | `1`                              |
 | persistence.enabled | Persist the Data and Log files for SQL Server                                               | `false`                          |
 | persistence.existingDataClaim | Identify an existing Claim to be used for the Data Directory                      | `Commented Out`                  |
 | persistence.storageClass      | Storage Class to be used                                                          | `Commented Out`                  |

--- a/charts/mssqlserver-2022/README.md
+++ b/charts/mssqlserver-2022/README.md
@@ -107,6 +107,7 @@ The configuration parameters in this section control the resources requested and
 | pod.annotations   | Kubernetes pod annotations                                                                    | `{}`                             |
 | pod.labels        | Kubernetes pod labels                                                                         | `{}`                             |
 | collation        | Default collation for SQL Server                                                               | `SQL_Latin1_General_CP1_CI_AS`   |
+| dataDir          | Specify the default SQL data directory                                                         | `/var/opt/mssql`                 |
 | lcid             | Default languages for SQL Server                                                               | `1033`                           |
 | hadr             | Enable Availability Group                                                                      | `0`                              |
 | replicaCount     | Set the number of replica                                                                      | `1`                              |

--- a/charts/mssqlserver-2022/templates/deployment.yaml
+++ b/charts/mssqlserver-2022/templates/deployment.yaml
@@ -55,7 +55,7 @@ spec:
                  name: {{ template "mssql.fullname" . }}-secret
                  key: sapassword
             - name: MSSQL_DATA_DIR
-              value: /var/opt/mssql
+              value: {{ .Values.dataDir }}
             - name: MSSQL_TCP_PORT
               value: "{{ .Values.service.port }}"
             - name: MSSQL_COLLATION

--- a/charts/mssqlserver-2022/values.yaml
+++ b/charts/mssqlserver-2022/values.yaml
@@ -3,6 +3,7 @@ acceptEula:
 edition:
   value: Developer
 collation: SQL_Latin1_General_CP1_CI_AS
+dataDir: /var/opt/mssql
 lcid: 1033
 hadr: 0
 replicaCount: 1

--- a/charts/mssqlserver-2022/values.yaml
+++ b/charts/mssqlserver-2022/values.yaml
@@ -5,6 +5,7 @@ edition:
 collation: SQL_Latin1_General_CP1_CI_AS
 lcid: 1033
 hadr: 0
+replicaCount: 1
 # Override sapassword in templates/secret.yaml
 # sapassword: "MyStrongPassword1234"
 image:


### PR DESCRIPTION
* add a new value `dataDir` to be able to change the default MSSQL data directory
* set a default value for `replicaCount`