### PR TITLE
MSSql: Support NodePort

### DIFF
--- a/charts/mssqlserver-2019/README.md
+++ b/charts/mssqlserver-2019/README.md
@@ -100,6 +100,7 @@ The configuration parameters in this section control the resources requested and
 | service.headless   | Allows you to setup a headless service  | `false`  |
 | service.type     | Service Type                                                                                   | `ClusterIP`                      |
 | service.port     | Service Port                                                                                   | `1433`                           |
+| service.nodePort | Service NodePort                                                                               | `Random Port`                    |
 | service.annotations | Kubernetes service annotations                                                              | `{}`                             |
 | service.labels   | Kubernetes service labels                                                                      | `{}`                             |
 | deployment.annotations | Kubernetes deployment annotations                                                        | `{}`                             |

--- a/charts/mssqlserver-2019/templates/service.yaml
+++ b/charts/mssqlserver-2019/templates/service.yaml
@@ -24,6 +24,7 @@ spec:
   ports:
   - name: mssql
     port: {{ .Values.service.port }}
+    nodePort: {{ .Values.service.nodePort }}
     targetPort: mssql
     protocol: TCP
   selector:

--- a/charts/mssqlserver-2019/templates/service.yaml
+++ b/charts/mssqlserver-2019/templates/service.yaml
@@ -24,7 +24,9 @@ spec:
   ports:
   - name: mssql
     port: {{ .Values.service.port }}
+    {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     targetPort: mssql
     protocol: TCP
   selector:

--- a/charts/mssqlserver-2022/README.md
+++ b/charts/mssqlserver-2022/README.md
@@ -100,6 +100,7 @@ The configuration parameters in this section control the resources requested and
 | service.headless   | Allows you to setup a headless service  | `false`  |
 | service.type     | Service Type                                                                                   | `ClusterIP`                      |
 | service.port     | Service Port                                                                                   | `1433`                           |
+| service.nodePort | Service NodePort                                                                               | `Random Port`                    |
 | service.annotations | Kubernetes service annotations                                                              | `{}`                             |
 | service.labels   | Kubernetes service labels                                                                      | `{}`                             |
 | deployment.annotations | Kubernetes deployment annotations                                                        | `{}`                             |

--- a/charts/mssqlserver-2022/templates/service.yaml
+++ b/charts/mssqlserver-2022/templates/service.yaml
@@ -24,6 +24,7 @@ spec:
   ports:
   - name: mssql
     port: {{ .Values.service.port }}
+    nodePort: {{ .Values.service.nodePort }}
     targetPort: mssql
     protocol: TCP
   selector:

--- a/charts/mssqlserver-2022/templates/service.yaml
+++ b/charts/mssqlserver-2022/templates/service.yaml
@@ -24,7 +24,9 @@ spec:
   ports:
   - name: mssql
     port: {{ .Values.service.port }}
+    {{- if .Values.service.nodePort }}
     nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     targetPort: mssql
     protocol: TCP
   selector:


### PR DESCRIPTION
Allow nodePort to be set for mssql, instead of k8s randomly assigning one all the time.