### PR TITLE
[Bytesafe] Add support for serviceAccountName

### DIFF
--- a/charts/bytesafe/templates/statefulSet.yaml
+++ b/charts/bytesafe/templates/statefulSet.yaml
@@ -4,54 +4,58 @@ metadata:
   name: {{ template "bytesafe.fullname" . }}
   labels:
     {{- include "bytesafe.labels" . | nindent 4 }}
-{{- if .Values.statefulSet.labels }}
-{{ toYaml .Values.statefulSet.labels | indent 4 }}
-{{- end }}
-{{- if .Values.statefulSet.annotations }}
+  {{- if .Values.statefulSet.labels }}
+  {{ toYaml .Values.statefulSet.labels | indent 4 }}
+  {{- end }}
+  {{- if .Values.statefulSet.annotations }}
   annotations:
-{{ toYaml .Values.statefulSet.annotations | indent 4 }}
-{{- end }}
+    {{ toYaml .Values.statefulSet.annotations | indent 4 }}
+  {{- end }}
 spec:
+  serviceName: {{ include "bytesafe.fullname" . }}
   selector:
     matchLabels:
-    {{- include "bytesafe.selectorLabels" . | nindent 6 }}
-  replicas: {{.Values.replicaCount}}
+      {{- include "bytesafe.selectorLabels" . | nindent 6 }}
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
-      {{- include "bytesafe.selectorLabels" . | nindent 8 }}
-    {{- if .Values.pod.labels }}
-{{ toYaml .Values.pod.labels | indent 8 }}
-{{- end }}
-{{- if .Values.pod.annotations }}
+        {{- include "bytesafe.selectorLabels" . | nindent 8 }}
+      {{- if .Values.pod.labels }}
+        {{ toYaml .Values.pod.labels | indent 8 }}
+      {{- end }}
+      {{- if .Values.pod.annotations }}
       annotations:
-{{ toYaml .Values.pod.annotations | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.pod.annotations | indent 8 }}
+      {{- end }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      automountServiceAccountToken: true
+      serviceAccountName: {{ if .Values.serviceAccount.name }}{{ .Values.serviceAccount.name }}{{ else }}{{ include "bytesafe.fullname" . }}{{ end }}
+      {{- end }}
       volumes:
         - name: bytesafe-tmp
           emptyDir: {}
-      {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+        {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
         - name: bytesafe-data
           persistentVolumeClaim:
-      {{- with .Values.persistence.existingClaim }}
+            {{- with .Values.persistence.existingClaim }}
             claimName: {{ tpl . $ }}
-      {{- end }}
-      {{- else if .Values.persistence.enabled }}
+            {{- end }}
+        {{- else if .Values.persistence.enabled }}
         - name: bytesafe-data
           persistentVolumeClaim:
             claimName: {{ template "bytesafe.fullname" . }}-data
-      {{- end }}
+        {{- end }}
       containers:
         - name: bytesafe-ce
-          image: {{.Values.image.repository}}:{{.Values.image.tag}}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           env:
             - name: DATA_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: DATA_ENCRYPTION_KEY
-                  
             {{- if and .Values.redis.enabled .Values.redis.auth.existingSecret }}
             - name: REDIS_PASSWORD
               valueFrom:
@@ -65,7 +69,7 @@ spec:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: REDIS_PASSWORD
-            {{- end}}
+            {{- end }}
             {{- if and .Values.externalRedis.enabled .Values.externalRedis.existingSecret }}
             - name: REDIS_PASSWORD
               valueFrom:
@@ -79,8 +83,7 @@ spec:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: REDIS_PASSWORD
-            {{- end}}
-              
+            {{- end }}
             {{- if and .Values.postgresql.enabled .Values.postgresql.auth.existingSecret }}
             - name: DB_ADMIN_PASSWORD
               valueFrom:
@@ -104,7 +107,7 @@ spec:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: DB_PASSWORD
-            {{- end}}
+            {{- end }}
             {{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret }}
             - name: DB_ADMIN_PASSWORD
               valueFrom:
@@ -128,14 +131,14 @@ spec:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: DB_PASSWORD
-            {{- end}}
+            {{- end }}
             {{- if .Values.smtp.enabled }}
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: SMTP_PASSWORD
-            {{- end}}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: bytesafe-config


### PR DESCRIPTION
This PR introduces a few updates to the `statefulSet.yaml` template:
- Added conditions to check the creation of a ServiceAccount and set `automountServiceAccountToken` to true as well as referenced the correct ServiceAccountName value.
- The `serviceName` attribute under `spec` has been explicitly set to use the `bytesafe.fullname` template, ensuring clarity in service references.
- Indentation has been corrected across various sections to ensure consistency and improve the visual hierarchy of the YAML structure.
- Conditional blocks for `statefulSet.labels`, `statefulSet.annotations`, `pod.labels`, and `pod.annotations` have been adjusted to include proper indentation and spacing, making it easier to distinguish between nested properties.