### PR TITLE
[Bytesafe] Add support for PostgreSQL `sslmode` parameter

### DIFF
--- a/charts/bytesafe/Chart.yaml
+++ b/charts/bytesafe/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "1.0.4"
+appVersion: "1.0.12"
 description: Bytesafe - A Security Platform That Protects You From Open Source Software Supply Chain Attacks
 home: https://bytesafe.dev/
 icon: https://gdm-catalog-fmapi-prod.imgix.net/ProductLogo/27c22bec-6e47-479d-9856-efd5d3be4fba.jpeg?auto=format&q=50&w=128&h=128&fit=max&dpr=3
@@ -9,7 +9,7 @@ maintainers:
 name: bytesafe-ce
 sources:
 - https://github.com/SimCubeLtd/simcube-helm-charts
-version: "1.0.4"
+version: "1.0.12"
 
 dependencies:
   - name: postgresql

--- a/charts/bytesafe/templates/config.yaml
+++ b/charts/bytesafe/templates/config.yaml
@@ -45,6 +45,12 @@ data:
   DB_PORT: {{ .Values.externalDatabase.port | quote}}
 {{- end }}
 
+{{- if and .Values.postgresql.enabled .Values.postgresql.auth.sslmode }}
+  DB_SSLMODE: {{ .Values.postgresql.auth.sslmode | quote }}
+{{- else if and .Values.externalDatabase.enabled .Values.externalDatabase.sslmode }}
+  DB_SSLMODE: {{ .Values.externalDatabase.sslmode | quote}}
+{{- end }}
+
 {{- if .Values.smtp.enabled }}
   SMTP_HOST: {{ .Values.smtp.host }}
   SMTP_PORT: {{ .Values.smtp.port | quote }}

--- a/charts/bytesafe/templates/statefulSet.yaml
+++ b/charts/bytesafe/templates/statefulSet.yaml
@@ -4,54 +4,58 @@ metadata:
   name: {{ template "bytesafe.fullname" . }}
   labels:
     {{- include "bytesafe.labels" . | nindent 4 }}
-{{- if .Values.statefulSet.labels }}
-{{ toYaml .Values.statefulSet.labels | indent 4 }}
-{{- end }}
-{{- if .Values.statefulSet.annotations }}
+  {{- if .Values.statefulSet.labels }}
+  {{ toYaml .Values.statefulSet.labels | indent 4 }}
+  {{- end }}
+  {{- if .Values.statefulSet.annotations }}
   annotations:
-{{ toYaml .Values.statefulSet.annotations | indent 4 }}
-{{- end }}
+    {{ toYaml .Values.statefulSet.annotations | indent 4 }}
+  {{- end }}
 spec:
+  serviceName: {{ include "bytesafe.fullname" . }}
   selector:
     matchLabels:
-    {{- include "bytesafe.selectorLabels" . | nindent 6 }}
-  replicas: {{.Values.replicaCount}}
+      {{- include "bytesafe.selectorLabels" . | nindent 6 }}
+  replicas: {{ .Values.replicaCount }}
   template:
     metadata:
       labels:
-      {{- include "bytesafe.selectorLabels" . | nindent 8 }}
-    {{- if .Values.pod.labels }}
-{{ toYaml .Values.pod.labels | indent 8 }}
-{{- end }}
-{{- if .Values.pod.annotations }}
+        {{- include "bytesafe.selectorLabels" . | nindent 8 }}
+      {{- if .Values.pod.labels }}
+        {{ toYaml .Values.pod.labels | indent 8 }}
+      {{- end }}
+      {{- if .Values.pod.annotations }}
       annotations:
-{{ toYaml .Values.pod.annotations | indent 8 }}
-{{- end }}
+        {{ toYaml .Values.pod.annotations | indent 8 }}
+      {{- end }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      automountServiceAccountToken: true
+      serviceAccountName: {{ if .Values.serviceAccount.name }}{{ .Values.serviceAccount.name }}{{ else }}{{ include "bytesafe.fullname" . }}{{ end }}
+      {{- end }}
       volumes:
         - name: bytesafe-tmp
           emptyDir: {}
-      {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
+        {{- if and .Values.persistence.enabled .Values.persistence.existingClaim }}
         - name: bytesafe-data
           persistentVolumeClaim:
-      {{- with .Values.persistence.existingClaim }}
+            {{- with .Values.persistence.existingClaim }}
             claimName: {{ tpl . $ }}
-      {{- end }}
-      {{- else if .Values.persistence.enabled }}
+            {{- end }}
+        {{- else if .Values.persistence.enabled }}
         - name: bytesafe-data
           persistentVolumeClaim:
             claimName: {{ template "bytesafe.fullname" . }}-data
-      {{- end }}
+        {{- end }}
       containers:
         - name: bytesafe-ce
-          image: {{.Values.image.repository}}:{{.Values.image.tag}}
+          image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
           env:
             - name: DATA_ENCRYPTION_KEY
               valueFrom:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: DATA_ENCRYPTION_KEY
-                  
             {{- if and .Values.redis.enabled .Values.redis.auth.existingSecret }}
             - name: REDIS_PASSWORD
               valueFrom:
@@ -65,7 +69,7 @@ spec:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: REDIS_PASSWORD
-            {{- end}}
+            {{- end }}
             {{- if and .Values.externalRedis.enabled .Values.externalRedis.existingSecret }}
             - name: REDIS_PASSWORD
               valueFrom:
@@ -79,8 +83,7 @@ spec:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: REDIS_PASSWORD
-            {{- end}}
-              
+            {{- end }}
             {{- if and .Values.postgresql.enabled .Values.postgresql.auth.existingSecret }}
             - name: DB_ADMIN_PASSWORD
               valueFrom:
@@ -104,7 +107,7 @@ spec:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: DB_PASSWORD
-            {{- end}}
+            {{- end }}
             {{- if and .Values.externalDatabase.enabled .Values.externalDatabase.existingSecret }}
             - name: DB_ADMIN_PASSWORD
               valueFrom:
@@ -128,14 +131,14 @@ spec:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: DB_PASSWORD
-            {{- end}}
+            {{- end }}
             {{- if .Values.smtp.enabled }}
             - name: SMTP_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: bytesafe-secrets
                   key: SMTP_PASSWORD
-            {{- end}}
+            {{- end }}
           envFrom:
             - configMapRef:
                 name: bytesafe-config

--- a/charts/bytesafe/values.yaml
+++ b/charts/bytesafe/values.yaml
@@ -1,7 +1,7 @@
 image:
   repository: bytesafe/bytesafe-ce
   pullPolicy: IfNotPresent
-  tag: "v1.0.4"
+  tag: "v1.0.12"
 
 imagePullSecrets: []
 nameOverride: ""
@@ -115,6 +115,9 @@ postgresql:
     ## @param postgresql.auth.database Database to create when deploying the PostgreSQL chart
     ##
     database: bytesafe
+    ## @param postgresql.auth.sslmode Use SSL connections to encrypt client/server communications using TLS protocols for increased security.
+    ##
+    sslmode: prefer
   ## PostgreSQL Primary parameters
   ##
   primary:
@@ -181,6 +184,9 @@ externalDatabase:
   ## @param externalDatabase.port Port of an external PostgreSQL to connect (only if postgresql.enabled=false)
   ##
   port: 5432
+  ## @param externalDatabase.sslmode Use SSL connections to encrypt client/server communications using TLS protocols for increased security.
+  ##
+  sslmode: prefer
   
 redis:
   ## Bitnami Redis image


### PR DESCRIPTION
This PR introduces the following changes to the `config.yaml` template and `values.yaml` supporting bytesafe-ce@v1.0.12:
- Creates and configures the `DB_SSLMODE` environment variable using the `config.yaml` template.
- Sets the default value for `sslmode` to `prefer` using the `.Values.postgresql.auth.sslmode` and `.Values.externalDatabase.sslmode` parameters.
- Bumps the default Chart version, appVersion, and tag values from 1.0.4 to 1.0.12

PS: This PR is built on top of changes introduced in https://github.com/SimCubeLtd/simcube-helm-charts/pull/44